### PR TITLE
Remove direction parameter

### DIFF
--- a/app/controllers/concerns/cursor_paginatable.rb
+++ b/app/controllers/concerns/cursor_paginatable.rb
@@ -1,7 +1,7 @@
 module CursorPaginatable
-  def paginate_with_cursor(relation, items: 20, before: nil, by: :id, direction: :desc)
+  def paginate_with_cursor(relation, items: 20, before: nil, by: :id)
     relation = relation.where(by => ..before) if before.present?
-    relation = relation.order(by => direction).limit(items + 1).to_a
+    relation = relation.order(by => :desc).limit(items + 1).to_a
     cursor = relation.pop.public_send(by) if relation.size > items
 
     [relation, cursor]


### PR DESCRIPTION
If direction would be set to `:asc` then the filter would need to be flipped to `before..`, or rather, with better naming to `after..`. But direction is never changed anywhere so in the spirit of YAGNI it's better to simplify the code and just hardcode :desc.

Also see this comment on the related blog post for the background of this change: https://github.com/radanskoric/radanskoric.github.io/discussions/22#discussioncomment-14571021