### PR TITLE
Inherit canonical descriptive fields onto linked coffee bags

### DIFF
--- a/app/models/coffee_bag.rb
+++ b/app/models/coffee_bag.rb
@@ -5,6 +5,10 @@ class CoffeeBag < ApplicationRecord
   performs :refresh_shot_values
 
   DISPLAY_ATTRIBUTES = %w[roast_level country region farm farmer variety elevation processing harvest_time quality_score tasting_notes place_of_purchase].freeze
+  # Descriptive fields a personal bag inherits from its canonical (curated)
+  # record. Excludes the bag-owned name and fields the canonical lacks (farm,
+  # quality_score, place_of_purchase).
+  CANONICAL_INHERITED_ATTRIBUTES = %w[roast_level country region farmer variety elevation processing harvest_time tasting_notes].freeze
 
   belongs_to :roaster, touch: true
   belongs_to :canonical_coffee_bag, optional: true
@@ -19,6 +23,7 @@ class CoffeeBag < ApplicationRecord
   validates :name, presence: true, uniqueness: {scope: %i[roaster_id roast_date], case_sensitive: false} # rubocop:disable Rails/UniqueValidationWithoutIndex
   validate :defrosted_date_after_frozen_date
 
+  before_validation :inherit_descriptive_fields_from_canonical, if: -> { canonical_coffee_bag_id.present? && canonical_coffee_bag_id_changed? }
   after_save_commit :refresh_shot_values_later, if: -> { saved_changes.keys.intersect?(%w[name roast_date roast_level roaster_id]) }
 
   scope :filter_by_name, ->(name) { where("LOWER(coffee_bags.name) = ?", name.downcase.squish) }
@@ -95,6 +100,14 @@ class CoffeeBag < ApplicationRecord
   end
 
   private
+
+  def inherit_descriptive_fields_from_canonical
+    if canonical_coffee_bag
+      CANONICAL_INHERITED_ATTRIBUTES.each do |attr|
+        self[attr] = canonical_coffee_bag.public_send(attr) if self[attr].blank?
+      end
+    end
+  end
 
   def defrosted_date_after_frozen_date
     if frozen_date.blank? && defrosted_date.present?

--- a/test/models/coffee_bag_test.rb
+++ b/test/models/coffee_bag_test.rb
@@ -141,4 +141,19 @@ class CoffeeBagTest < ActiveSupport::TestCase
       coffee_bag.update!(name: "Updated")
     end
   end
+
+  test "inherits blank descriptive fields from canonical when linked, preserving set ones" do
+    canonical_roaster = CanonicalRoaster.create!(name: "Luma")
+    canonical = CanonicalCoffeeBag.create!(name: "Kiambu", canonical_roaster:, roast_level: "Light", country: "Kenya", region: "Kiambu", farmer: "Smallholders", variety: "SL28", tasting_notes: "Black currant")
+    coffee_bag = create(:coffee_bag, roaster:, country: nil, region: "My own region")
+
+    coffee_bag.update!(canonical_coffee_bag: canonical)
+
+    assert_equal "Kenya", coffee_bag.country         # was blank -> inherited
+    assert_equal "Smallholders", coffee_bag.farmer
+    assert_equal "SL28", coffee_bag.variety
+    assert_equal "Black currant", coffee_bag.tasting_notes
+    assert_equal "Light", coffee_bag.roast_level
+    assert_equal "My own region", coffee_bag.region  # already set -> preserved
+  end
 end

--- a/test/models/coffee_bag_test.rb
+++ b/test/models/coffee_bag_test.rb
@@ -148,6 +148,7 @@ class CoffeeBagTest < ActiveSupport::TestCase
     coffee_bag = create(:coffee_bag, roaster:, country: nil, region: "My own region")
 
     coffee_bag.update!(canonical_coffee_bag: canonical)
+    coffee_bag.reload
 
     assert_equal "Kenya", coffee_bag.country         # was blank -> inherited
     assert_equal "Smallholders", coffee_bag.farmer
@@ -155,5 +156,46 @@ class CoffeeBagTest < ActiveSupport::TestCase
     assert_equal "Black currant", coffee_bag.tasting_notes
     assert_equal "Light", coffee_bag.roast_level
     assert_equal "My own region", coffee_bag.region  # already set -> preserved
+  end
+
+  test "does not wipe descriptive fields when canonical is later unlinked" do
+    canonical_roaster = CanonicalRoaster.create!(name: "Luma")
+    canonical = CanonicalCoffeeBag.create!(name: "Kiambu", canonical_roaster:, country: "Kenya", variety: "SL28")
+    coffee_bag = create(:coffee_bag, roaster:, country: nil)
+    coffee_bag.update!(canonical_coffee_bag: canonical)
+
+    coffee_bag.update!(canonical_coffee_bag: nil)
+    coffee_bag.reload
+
+    assert_equal "Kenya", coffee_bag.country
+    assert_equal "SL28", coffee_bag.variety
+  end
+
+  test "re-linking to a different canonical fills only still-blank fields" do
+    canonical_roaster = CanonicalRoaster.create!(name: "Luma")
+    first = CanonicalCoffeeBag.create!(name: "First", canonical_roaster:, country: "Kenya")
+    second = CanonicalCoffeeBag.create!(name: "Second", canonical_roaster:, country: "Ethiopia", variety: "Heirloom")
+    coffee_bag = create(:coffee_bag, roaster:, country: nil, variety: nil)
+
+    coffee_bag.update!(canonical_coffee_bag: first)
+    coffee_bag.update!(canonical_coffee_bag: second)
+    coffee_bag.reload
+
+    assert_equal "Kenya", coffee_bag.country    # kept from first (no longer blank)
+    assert_equal "Heirloom", coffee_bag.variety # was still blank -> filled from second
+  end
+
+  test "leaves fields the canonical lacks untouched" do
+    canonical_roaster = CanonicalRoaster.create!(name: "Luma")
+    canonical = CanonicalCoffeeBag.create!(name: "Kiambu", canonical_roaster:, country: "Kenya")
+    coffee_bag = create(:coffee_bag, roaster:, farm: "My Farm", quality_score: "88", place_of_purchase: "Local shop", country: nil)
+
+    coffee_bag.update!(canonical_coffee_bag: canonical)
+    coffee_bag.reload
+
+    assert_equal "My Farm", coffee_bag.farm
+    assert_equal "88", coffee_bag.quality_score
+    assert_equal "Local shop", coffee_bag.place_of_purchase
+    assert_equal "Kenya", coffee_bag.country
   end
 end


### PR DESCRIPTION
I am integrating Decenza (DE1 coffee app https://github.com/Kulitorum/Decenza) with your premium bean bags and coffee management. I was surprised that the bean information did not get added to the bag, so though I would provide what I hope is a patch to show what I am thinking. Let me know if you have any questions.

Jeff

## Problem

When a personal `CoffeeBag` is linked to a `CanonicalCoffeeBag`, the origin data (country, region, farmer, variety, elevation, processing, harvest_time, tasting_notes, roast_level) lives only on the canonical record. The personal bag — which is what `CoffeeBag#to_api_json` and the bag edit page show — stays blank.

This shows up clearly with Decent uploads: `Parsers::Base#set_coffee_bag` find-or-creates the personal bag from `bean_brand`/`bean_type`/`roast_date` and links the shot, but never sets the descriptive fields. Clients then link the bag to its canonical (or send `canonical_coffee_bag_id`), yet the bag still renders empty. Every client ends up re-pushing data the server already has on the canonical.

## Change

When a bag is linked to a canonical (`canonical_coffee_bag_id` set/changed), inherit the canonical's descriptive fields into the bag's **blank** ones. Fields the user already set are preserved; fields the canonical doesn't carry (`farm`, `quality_score`, `place_of_purchase`) and the bag-owned `name` are untouched.

```ruby
before_validation :inherit_descriptive_fields_from_canonical,
  if: -> { canonical_coffee_bag_id.present? && canonical_coffee_bag_id_changed? }
```

Now any path that links a canonical — API, importer, UI — surfaces the origin data server-side for all clients, and a client linking the canonical no longer needs to push the descriptive fields at all.

## Test

`test/models/coffee_bag_test.rb` — links a bag to a canonical and asserts blank fields are inherited while a user-set field is preserved.

(I couldn't run the suite locally — no Ruby 4.0.5 toolchain on this machine — so I'm relying on CI.)

## Related (not in this PR, happy to follow up)

On a Decent shot PATCH that sets `canonical_coffee_bag_id`, `Shot#refresh_coffee_bag_fields` overwrites it with the linked bag's (often `nil`) canonical, discarding the value. Linking the **bag** to its canonical (as this PR rewards) is the clean way around it, but if you'd prefer the shot to promote its canonical up to a bag that lacks one, I can add that — wanted your read on the intended direction first.