### PR TITLE
Expose created_at/updated_at on canonical coffee bag API results

### DIFF
--- a/app/controllers/api/canonical_coffee_bags_controller.rb
+++ b/app/controllers/api/canonical_coffee_bags_controller.rb
@@ -11,7 +11,7 @@ module Api
     private
 
     def coffee_bag_json(coffee_bag)
-      coffee_bag.attributes.slice("id", "canonical_roaster_id", "name", "url", *CanonicalCoffeeBag::DISPLAY_ATTRIBUTES).tap do |json|
+      coffee_bag.attributes.slice("id", "canonical_roaster_id", "name", "url", "created_at", "updated_at", *CanonicalCoffeeBag::DISPLAY_ATTRIBUTES).tap do |json|
         json["canonical_roaster_name"] = coffee_bag.canonical_roaster.name
       end
     end

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1780,6 +1780,12 @@ components:
         tasting_notes:
           type: string
           nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
 
     CanonicalCoffeeBagListResponse:
       type: object

--- a/test/controllers/api/canonical_coffee_bags_controller_test.rb
+++ b/test/controllers/api/canonical_coffee_bags_controller_test.rb
@@ -18,6 +18,8 @@ module Api
       assert_equal "Ethiopia", json_response["data"].first["country"]
       assert_equal "Heirloom", json_response["data"].first["variety"]
       assert_equal "Peach", json_response["data"].first["tasting_notes"]
+      assert_equal coffee_bag.created_at.iso8601(3), json_response["data"].first["created_at"]
+      assert_equal coffee_bag.updated_at.iso8601(3), json_response["data"].first["updated_at"]
       assert_equal 1, json_response["paging"]["count"]
     end
 


### PR DESCRIPTION
## Why

The canonical DB can hold near-duplicate submissions of the same coffee — e.g. `GET /api/canonical_coffee_bags?q=hometown` currently returns three separate "Sweet Bloom Coffee · Hometown Blend" entries with distinct ids, differing only slightly in roast level / elevation / tasting notes (one comes from a `hometown-blend-copy` product URL).

API consumers that show these results in a picker (I'm building the bean search in [Decenza](https://github.com/Kulitorum/Decenza), a DE1 controller app) can display the descriptive fields to tell the variants apart, but have no way to rank or label them by recency: `created_at`/`updated_at` exist on the table but the serializer strips them.

## What

- Add `created_at` and `updated_at` to the index JSON (`coffee_bag_json` slice).
- Document both fields in the `CanonicalCoffeeBagSummary` OpenAPI schema.
- Extend the controller test to assert they're returned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)